### PR TITLE
Make RatesReader return a datetime object rather than an int

### DIFF
--- a/atlas/models.py
+++ b/atlas/models.py
@@ -65,16 +65,16 @@ class HistoricalValues(BaseModel):
     point_id: str
     values: Dict[AggregateBy, PointValues]
 
-class HourlyRate(BaseModel):
+class HistoricalHourlyRate(BaseModel):
     start: int
     rate: float
 
 class HourlyRates(BaseModel):
-	usage_rate: List[HourlyRate] = []
-	maximum_demand_charge: List[HourlyRate] = []
-	time_of_use_demand_charge: List[HourlyRate] = []
-	day_ahead_market_rate: List[HourlyRate] = []
-	real_time_market_rate: List[HourlyRate] = []
+    usage_rate: List[HistoricalHourlyRate] = []
+    maximum_demand_charge: List[HistoricalHourlyRate] = []
+    time_of_use_demand_charge: List[HistoricalHourlyRate] = []
+    day_ahead_market_rate: List[HistoricalHourlyRate] = []
+    real_time_market_rate: List[HistoricalHourlyRate] = []
 
 class DeviceKind(str, Enum):
     compressor = "compressor"

--- a/atlas/rates.py
+++ b/atlas/rates.py
@@ -7,6 +7,10 @@ from .atlas_client import AtlasClient, HourlyRates
 class RateFilter(BaseModel):
     facilities: List[str]
 
+class HourlyRate(BaseModel):
+    start: datetime
+    rate: float
+
 class RatesReader:
     """
     High level API Client for retrieving energy rates from the ATLAS platform.
@@ -54,11 +58,13 @@ class RatesReader:
             start = datetime.now() - timedelta(days=1)
         if end is None:
             end = datetime.now()
-        result = {}
 
+        result = {}
         for f in facilities:
             try:
-                result[f.short_name] = self.client.get_hourly_rates(f.organization_id, f.agents[0].agent_id, start, end)
+                result[f.short_name] = {k: [HourlyRate(start=datetime.fromtimestamp(d.start), rate=d.rate) for d in v]
+                                        for k,v in self.client.get_hourly_rates(f.organization_id, f.agents[0].agent_id, start, end)}
+
             except Exception as e:
                 raise Exception(f"Error retrieving rates for facility {f.display_name}: {e}")
 


### PR DESCRIPTION
For consistency with the MetricsReader, RatesReader should return HourlyRate objects that contain a timestamp for the start date, rather than an int that must then be converted.

- Rename the original HourlyRate dataclass that expects an int to HistoricalHourlyRate (analogous to HistoricalValues for MetricsReader)
- Create a new HourlyRate dataclass that expects a datetime object for the 'start' parameter.
- Update RatesReader to unpack the returned values from the HourlyRate object and convert the timestamp using datetime.fromtimestamp within the new data class definition