### PR TITLE
Use Current Deployment Blueprint Version for Listing Devices

### DIFF
--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -259,13 +259,15 @@ class AtlasClient:
 
         Returns
         -------
-        Dict
-            Current deployment information
+        Deployment
+            Current Deployment at the facility including active blueprint version
 
         Raises
         ------
         AtlasHTTPError
             Raised if an error occurs while making the request
+        KeyError
+            Raised if an error occurs while parsing the response
         """
         url = f"/orgs/{org_id}/agents/{agent_id}/site-narratives/deployments/current"
         try:

--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -50,9 +50,9 @@ class AtlasClient:
 
         return [Facility(**facility) for facility in facilities]
 
-    def list_devices(self, org_id: str, agent_id: str, version: str | None = None) -> List[Device]:
+    def list_devices(self, org_id: str, agent_id: str) -> List[Device]:
         """
-        List all devices for a given facility.
+        List all devices for a given facility. Uses the active deployment to get the devices.
 
         Parameters
         ----------
@@ -60,8 +60,6 @@ class AtlasClient:
             organization ID associated with the facility as returned by list_facilities
         agent_id : str
             agent ID associated with the facility as returned by list_facilities
-        version : str | None, optional
-            blueprint version of the devices to return, by default None gets the latest but not neccesarily the latest deployed version
         
         Returns
         -------
@@ -73,8 +71,9 @@ class AtlasClient:
         AtlasHTTPError
             Raised if an error occurs while making the request
         """
+        active_deployment = self._get_current_deployment(org_id, agent_id)
         url = f"/orgs/{org_id}/agents/{agent_id}/devices"
-        params = { "version": version } if version else {}
+        params = { "version": active_deployment.blueprint_version }
 
         try:
             response = self.client.request("GET", url, params=params)
@@ -242,7 +241,7 @@ class AtlasClient:
 
         return facilities
 
-    def get_current_deployment(
+    def _get_current_deployment(
             self,
             org_id: str,
             agent_id: str,

--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -52,7 +52,7 @@ class AtlasClient:
 
     def list_devices(self, org_id: str, agent_id: str) -> List[Device]:
         """
-        List all devices for a given facility. Uses the active deployment to get the devices.
+        List all devices for a given facility. Uses the current deployment to get the devices.
 
         Parameters
         ----------

--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -279,7 +279,7 @@ class AtlasClient:
             return Deployment(
                 id=response_json["id"],
                 agent_id=response_json["agent_id"],
-                facility_id=response_json["org_id"],
+                organization_id=response_json["org_id"],
                 blueprint_version=response_json["blueprint"]["version"]
             )
         except KeyError as e:

--- a/atlas/metrics.py
+++ b/atlas/metrics.py
@@ -4,7 +4,7 @@ import re
 from typing import Dict, List, Optional
 from pydantic import BaseModel
 from .atlas_client import AtlasClient
-from .models import DeviceMetric, is_valid_metric, Facility, Device, Deployment
+from .models import DeviceMetric, is_valid_metric
 
 class Filter(BaseModel):
     facilities: List[str]
@@ -77,8 +77,7 @@ class MetricsReader:
         result = defaultdict(list)
         for facility in facilities:
             agent_id = facility.agents[0].agent_id
-            deployment = self._get_current_deployment(facility, agent_id)
-            devices = self._get_devices(facility, agent_id, deployment.blueprint_version)
+            devices = self._get_devices(facility, agent_id)
 
             for device in devices:
                 metrics_filter = [metric for metric in filter.metrics if metric.device_kind == device.kind]
@@ -98,12 +97,9 @@ class MetricsReader:
 
         return result
 
-    def _get_current_deployment(self, facility: Facility, agent_id: str) -> Deployment:
-        return self.client.get_current_deployment(facility.organization_id, agent_id)
-
-    def _get_devices(self, facility: Facility, agent_id: str, blueprint_version: int) -> List[Device]:
+    def _get_devices(self, facility, agent_id: str) -> List:
         try:
-            return self.client.list_devices(facility.organization_id, agent_id, str(blueprint_version))
+            return self.client.list_devices(facility.organization_id, agent_id)
         except Exception as e:
             raise Exception(f"Error listing devices for facility {facility.display_name}: {e}")
 

--- a/atlas/models.py
+++ b/atlas/models.py
@@ -113,6 +113,12 @@ device_metric_mapping = {
     DeviceKind.vessel: VesselMetric
 }
 
+class Deployment(BaseModel):
+    id: str
+    agent_id: str
+    facility_id: str
+    blueprint_version: int
+
 def is_valid_metric(metric: DeviceMetric) -> bool:
     """
     Check if the metric is valid for the given device kind.

--- a/atlas/models.py
+++ b/atlas/models.py
@@ -116,7 +116,7 @@ device_metric_mapping = {
 class Deployment(BaseModel):
     id: str
     agent_id: str
-    facility_id: str
+    organization_id: str
     blueprint_version: int
 
 def is_valid_metric(metric: DeviceMetric) -> bool:

--- a/examples/list_devices.py
+++ b/examples/list_devices.py
@@ -22,7 +22,7 @@ def list_devices(debug: bool = False) -> DeviceList:
     Return the device across all facilities indexed by facility name, then by
     device kind as well as a dictionary of all devices indexed by device ID.
     """
-    client = AtlasClient(debug)
+    client = AtlasClient(debug=debug)
     try:
         facilities = client.list_facilities()
     except Exception as e:
@@ -36,7 +36,9 @@ def list_devices(debug: bool = False) -> DeviceList:
             continue
         device_map = defaultdict(list)
         try:
-            devices = client.list_devices(facility.organization_id, facility.agents[0].agent_id)
+            # Get active deployment
+            deployment = client.get_current_deployment(facility.organization_id, facility.agents[0].agent_id)
+            devices = client.list_devices(facility.organization_id, facility.agents[0].agent_id, str(deployment.blueprint_version))
         except Exception as e:
             print(f"Error listing devices for facility {facility.display_name}: {e}")
             continue

--- a/examples/list_devices.py
+++ b/examples/list_devices.py
@@ -36,9 +36,7 @@ def list_devices(debug: bool = False) -> DeviceList:
             continue
         device_map = defaultdict(list)
         try:
-            # Get active deployment
-            deployment = client.get_current_deployment(facility.organization_id, facility.agents[0].agent_id)
-            devices = client.list_devices(facility.organization_id, facility.agents[0].agent_id, str(deployment.blueprint_version))
+            devices = client.list_devices(facility.organization_id, facility.agents[0].agent_id)
         except Exception as e:
             print(f"Error listing devices for facility {facility.display_name}: {e}")
             continue


### PR DESCRIPTION
* Added a call to fetch the current deployment inside of the `list_devices` method in the `AtlasClient` to ensure the list of actively deployed devices is returned
* Fixed debug param the `list_devices` example