### PR TITLE
add python-dateutil as a package requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "atlas-metrics"
 version = "0.0.3"
 description = "Python API Client for retrieving metric point values from the Atlas platform."
 requires-python = ">=3.11"
-dependencies = ["httpx", "orjson", "pydantic", "requests"]
+dependencies = ["httpx", "orjson", "pydantic", "requests", "python-dateutil"]
 
 [tool.hatch.build.targets.sdist]
 exclude = ["/examples"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ httpx==0.27.0
 orjson==3.10.3
 pydantic==2.7.1
 requests==2.32.1
+python-dateutil==2.9.0


### PR DESCRIPTION
dateutil (python-dateutil) was previously added as an import to specify the timezone in the Reader classes, and should be included in the package requirements