### PR TITLE
Use datetime.timzone instead of dateutil for utc timezone

### DIFF
--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -1,7 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
-
-from dateutil import tz
 
 from atlas.http_client import AtlasHTTPClient, AtlasHTTPError
 from atlas.models import (
@@ -191,8 +189,8 @@ class AtlasClient:
             "point_ids": point_ids,
             "start": start.strftime("%Y-%m-%dT%H:%M:%SZ")
             if start
-            else (datetime.now(tz.UTC) - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "end": end.strftime("%Y-%m-%dT%H:%M:%SZ") if end else datetime.now(tz.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            else (datetime.now(timezone.utc) - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "end": end.strftime("%Y-%m-%dT%H:%M:%SZ") if end else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "interval": interval,
             "aggregate_by": aggregate_by,
             "changes_only": changes_only,
@@ -248,10 +246,10 @@ class AtlasClient:
         params = {
             "since": since.strftime("%Y-%m-%dT%H:%M:%SZ")
             if since
-            else (datetime.now(tz.UTC) - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            else (datetime.now(timezone.utc) - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "until": until.strftime("%Y-%m-%dT%H:%M:%SZ")
             if until
-            else datetime.now(tz.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
         try:
             response = self.client.request("GET", url, params=params)

--- a/atlas/metrics.py
+++ b/atlas/metrics.py
@@ -1,9 +1,8 @@
 import re
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
-from dateutil import tz
 from pydantic import BaseModel
 
 from atlas.atlas_client import AtlasClient
@@ -204,7 +203,7 @@ class MetricsReader:
                     device_alias=device.alias,
                     aggregation=agg,
                     values=[
-                        MetricValue(timestamp=datetime.fromtimestamp(ts, tz=tz.UTC), value=val)
+                        MetricValue(timestamp=datetime.fromtimestamp(ts, tz=timezone.utc), value=val)
                         for ts, val in zip(timestamps, vals)
                     ],
                 )

--- a/atlas/models.py
+++ b/atlas/models.py
@@ -1,8 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Union
 
-from dateutil import tz
 from pydantic import BaseModel
 
 
@@ -94,7 +93,7 @@ class HistoricalHourlyRate(BaseModel):
 
     @property
     def start_datetime(self) -> datetime:
-        return datetime.fromtimestamp(self.start, tz=tz.UTC)
+        return datetime.fromtimestamp(self.start, tz=timezone.utc)
 
     def to_hourly_rate(self) -> HourlyRate:
         return HourlyRate(start=self.start_datetime, rate=self.rate)

--- a/atlas/rates.py
+++ b/atlas/rates.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
-from dateutil import tz
 from pydantic import BaseModel
 
 from atlas.atlas_client import AtlasClient
@@ -58,9 +57,9 @@ class RatesReader:
         """
         facilities = self.client.filter_facilities(filter.facilities)
         if start is None:
-            start = datetime.now(tz.UTC) - timedelta(days=1)
+            start = datetime.now(timezone.utc) - timedelta(days=1)
         if end is None:
-            end = datetime.now(tz.UTC)
+            end = datetime.now(timezone.utc)
         result = {}
 
         result = {}


### PR DESCRIPTION
* `dateutil` was being imported only retrieve the UTC timzone. There is no longer a need to install`python-dateutil` with this change.