### PR TITLE
Update to support controlled devices with metric types

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ current for all compressors:
 ```python
 Filter(metrics=[DeviceMetric(
     device_kind=DeviceKind.compressor,
-    alias_regexp=".*_motorCurrent"
+    alias_regexp=".*_motorCurrent",
+    metric_type=MetricType.control_point
 )
 ```
 
@@ -190,9 +191,20 @@ agent_id = "agent_id"
 devices = client.list_devices(org_id, agent_id)
 print(devices)
 
-# Get point IDs for device aliases
-point_aliases = ["alias1", "alias2"]
-point_ids = client.get_point_ids(org_id, agent_id, point_aliases)
+# Find point ids on devices
+device = devices[0]
+# control points:
+print(device.control_points)
+# metrics
+print(device.metrics)
+# outputs
+print(device.outputs)
+# conditions
+print(device.conditions)
+# settings
+print(device.settings)
+
+point_ids = ["73e697c8-6eae-44e1-a512-6c8083ea7904", "068fb8bb-4680-4cf1-ba29-57e71a80eb5a"]
 print(point_ids)
 
 # Get historical values

--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -101,6 +101,7 @@ class AtlasClient:
         for controlled_device in controlled_devices.get("values", []):
             device = Device(
                 id=controlled_device["device_id"],
+                name=controlled_device["name"],
                 alias=controlled_device["alias"],
                 kind=controlled_device["kind"],
                 control_points=[

--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from typing import Optional
 
 from atlas.http_client import AtlasHTTPClient, AtlasHTTPError
 from atlas.models import (
@@ -43,7 +43,7 @@ class AtlasClient:
         self.client = AtlasHTTPClient(refresh_token=refresh_token, debug=debug)
         self.client.refresh_access_token()
 
-    def list_facilities(self) -> List[Facility]:
+    def list_facilities(self) -> list[Facility]:
         """
         List facilities the logged in user has access to.
 
@@ -66,7 +66,7 @@ class AtlasClient:
 
         return [Facility(**facility) for facility in facilities]
 
-    def list_devices(self, org_id: str, agent_id: str) -> List[Device]:
+    def list_devices(self, org_id: str, agent_id: str) -> list[Device]:
         """
         List all devices for a given facility.
 
@@ -122,14 +122,14 @@ class AtlasClient:
         self,
         org_id: str,
         agent_id: str,
-        point_ids: List[str],
+        point_ids: list[str],
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
         interval: int = 60,
-        aggregate_by: List[AggregateBy] = ["avg"],
+        aggregate_by: list[AggregateBy] = ["avg"],
         changes_only: bool = False,
         scaled: bool = True,
-    ) -> List[HistoricalValues]:
+    ) -> list[HistoricalValues]:
         """
         Get historical point values. A single request may return multiple points
         and multiple aggregation methods for each point.
@@ -248,7 +248,7 @@ class AtlasClient:
         except ValueError as e:
             raise AtlasHTTPError(f"{e}, got {response}", response=response)
 
-    def filter_facilities(self, filter: List[str]) -> List[Facility]:
+    def filter_facilities(self, filter: list[str]) -> list[Facility]:
         try:
             all_facilities = self.list_facilities()
         except Exception as e:
@@ -308,7 +308,7 @@ class AtlasClient:
         except KeyError as e:
             raise AtlasHTTPError(f"Error parsing deployment: {e}, got {response_json}", response=response)
 
-    def _get_device_associations(self, org_id: str, agent_id: str) -> Dict[str, DeviceAssociations]:
+    def _get_device_associations(self, org_id: str, agent_id: str) -> dict[str, DeviceAssociations]:
         """
         Get to devices connections for a given facility by device ID.
 

--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -4,11 +4,8 @@ from typing import Dict, List, Optional
 from atlas.http_client import AtlasHTTPClient, AtlasHTTPError
 from atlas.models import (
     AggregateBy,
-    ControlledDeviceCondition,
-    ControlledDeviceControlPoint,
-    ControlledDeviceMetric,
-    ControlledDeviceOutput,
-    ControlledDeviceSetting,
+    Condition,
+    ControlPoint,
     Deployment,
     Device,
     DeviceAssociations,
@@ -16,6 +13,9 @@ from atlas.models import (
     HistoricalHourlyRates,
     HistoricalValues,
     HourlyRates,
+    Metric,
+    Output,
+    Setting,
 )
 
 
@@ -104,15 +104,12 @@ class AtlasClient:
                 alias=controlled_device["alias"],
                 kind=controlled_device["kind"],
                 control_points=[
-                    ControlledDeviceControlPoint(**control_point)
-                    for control_point in controlled_device.get("control_points", [])
+                    ControlPoint(**control_point) for control_point in controlled_device.get("control_points", [])
                 ],
-                metrics=[ControlledDeviceMetric(**metric) for metric in controlled_device.get("metrics", [])],
-                outputs=[ControlledDeviceOutput(**output) for output in controlled_device.get("outputs", [])],
-                conditions=[
-                    ControlledDeviceCondition(**condition) for condition in controlled_device.get("conditions", [])
-                ],
-                settings=[ControlledDeviceSetting(**setting) for setting in controlled_device.get("settings", [])],
+                metrics=[Metric(**metric) for metric in controlled_device.get("metrics", [])],
+                outputs=[Output(**output) for output in controlled_device.get("outputs", [])],
+                conditions=[Condition(**condition) for condition in controlled_device.get("conditions", [])],
+                settings=[Setting(**setting) for setting in controlled_device.get("settings", [])],
             )
             associations = device_associations.get(device.id, DeviceAssociations())
             device.upstream = associations.upstream

--- a/atlas/atlas_client.py
+++ b/atlas/atlas_client.py
@@ -4,8 +4,14 @@ from typing import Dict, List, Optional
 from atlas.http_client import AtlasHTTPClient, AtlasHTTPError
 from atlas.models import (
     AggregateBy,
+    ControlledDeviceCondition,
+    ControlledDeviceControlPoint,
+    ControlledDeviceMetric,
+    ControlledDeviceOutput,
+    ControlledDeviceSetting,
     Deployment,
     Device,
+    DeviceAssociations,
     Facility,
     HistoricalHourlyRates,
     HistoricalValues,
@@ -62,7 +68,7 @@ class AtlasClient:
 
     def list_devices(self, org_id: str, agent_id: str) -> List[Device]:
         """
-        List all devices for a given facility. Uses the current deployment to get the devices.
+        List all devices for a given facility.
 
         Parameters
         ----------
@@ -81,53 +87,39 @@ class AtlasClient:
         AtlasHTTPError
             Raised if an error occurs while making the request
         """
-        active_deployment = self._get_current_deployment(org_id, agent_id)
-        url = f"/orgs/{org_id}/agents/{agent_id}/devices"
-        params = {"version": active_deployment.blueprint_version}
+        url = f"/orgs/{org_id}/agents/{agent_id}/controlled-devices"
 
         try:
-            response = self.client.request("GET", url, params=params)
-            devices = response.json()
+            response = self.client.request("GET", url)
+            controlled_devices = response.json()
         except ValueError as e:
             raise AtlasHTTPError(f"{e}, got {response}", response=response)
 
-        return [Device(**device) for device in devices.get("values", [])]
+        devices: list[Device] = []
+        device_associations = self._get_device_associations(org_id, agent_id)
 
-    def get_point_ids(
-        self,
-        org_id: str,
-        agent_id: str,
-        point_aliases: List[str],
-    ) -> Dict[str, str]:
-        """
-        Retrieve point IDs given an agent and point aliases.
+        for controlled_device in controlled_devices.get("values", []):
+            device = Device(
+                id=controlled_device["device_id"],
+                alias=controlled_device["alias"],
+                kind=controlled_device["kind"],
+                control_points=[
+                    ControlledDeviceControlPoint(**control_point)
+                    for control_point in controlled_device.get("control_points", [])
+                ],
+                metrics=[ControlledDeviceMetric(**metric) for metric in controlled_device.get("metrics", [])],
+                outputs=[ControlledDeviceOutput(**output) for output in controlled_device.get("outputs", [])],
+                conditions=[
+                    ControlledDeviceCondition(**condition) for condition in controlled_device.get("conditions", [])
+                ],
+                settings=[ControlledDeviceSetting(**setting) for setting in controlled_device.get("settings", [])],
+            )
+            associations = device_associations.get(device.id, DeviceAssociations())
+            device.upstream = associations.upstream
+            device.downstream = associations.downstream
+            devices.append(device)
 
-        Parameters
-        ----------
-        org_id : str
-            organization ID associated with the facility as returned by list_facilities
-        agent_id : str
-            agent ID associated with the facility as returned by list_facilities
-        point_aliases : List[str]
-            list of point aliases as returned by list_devices
-
-        Returns
-        -------
-        Dict[str, str]
-            dictionary of point aliases to point IDs
-
-        Raises
-        ------
-        AtlasHTTPError
-            Raised if an error occurs while making the request
-        """
-        url = f"/orgs/{org_id}/agents/{agent_id}/point-ids"
-        payload = {"names": point_aliases}
-        try:
-            response = self.client.request("POST", url, json=payload)
-            return response.json()
-        except ValueError as e:
-            raise AtlasHTTPError(f"{e}, got {response}", response=response)
+        return devices
 
     def get_historical_values(
         self,
@@ -190,7 +182,9 @@ class AtlasClient:
             "start": start.strftime("%Y-%m-%dT%H:%M:%SZ")
             if start
             else (datetime.now(timezone.utc) - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "end": end.strftime("%Y-%m-%dT%H:%M:%SZ") if end else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "end": end.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if end
+            else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "interval": interval,
             "aggregate_by": aggregate_by,
             "changes_only": changes_only,
@@ -316,3 +310,41 @@ class AtlasClient:
             )
         except KeyError as e:
             raise AtlasHTTPError(f"Error parsing deployment: {e}, got {response_json}", response=response)
+
+    def _get_device_associations(self, org_id: str, agent_id: str) -> Dict[str, DeviceAssociations]:
+        """
+        Get to devices connections for a given facility by device ID.
+
+        Parameters
+        ----------
+        org_id : str
+            organization ID associated with the facility as returned by list_facilities
+        agent_id : str
+            agent ID associated with the facility as returned by list_facilities
+
+        Returns
+        -------
+        Dict[str, DeviceAssociations]
+            Dictionary of device IDs to device associations
+
+        Raises
+        ------
+        AtlasHTTPError
+            Raised if an error occurs while making the request
+        """
+        active_deployment = self._get_current_deployment(org_id, agent_id)
+        devices_url = f"/orgs/{org_id}/agents/{agent_id}/devices"  # used for connections only
+        params = {"version": active_deployment.blueprint_version}
+
+        try:
+            response = self.client.request("GET", devices_url, params=params)
+            devices = response.json()
+        except ValueError as e:
+            raise AtlasHTTPError(f"{e}, got {response}", response=response)
+
+        return {
+            device["id"]: DeviceAssociations(
+                upstream=device.get("upstream", []), downstream=device.get("downstream", [])
+            )
+            for device in devices.get("values", [])
+        }

--- a/atlas/metrics.py
+++ b/atlas/metrics.py
@@ -7,12 +7,12 @@ from pydantic import BaseModel
 
 from atlas.atlas_client import AtlasClient
 from atlas.models import (
-    ConstructType,
     ControlledDeviceConstruct,
     Device,
     DeviceMetric,
     Facility,
     HistoricalValues,
+    MetricType,
     is_valid_metric,
 )
 
@@ -133,18 +133,18 @@ class MetricsReader:
         self, device: Device, metrics: List[DeviceMetric]
     ) -> List[Dict[str, ControlledDeviceConstruct]]:
         result: Dict[str, ControlledDeviceConstruct] = {}
-        for construct_type in ConstructType:
+        for metric_type in MetricType:
             # Extract metric names and regex patterns
-            metric_names = {metric.name for metric in metrics if metric.construct_type == construct_type}
+            metric_names = {metric.name for metric in metrics if metric.metric_type == metric_type}
             metric_regexps = [
                 re.compile(metric.alias_regex)
                 for metric in metrics
-                if metric.construct_type == construct_type and metric.alias_regex
+                if metric.metric_type == metric_type and metric.alias_regex
             ]
             if not metric_names and not metric_regexps:
                 continue
 
-            contructs: list[ControlledDeviceConstruct] = getattr(device, f"{construct_type.value}s")
+            contructs: list[ControlledDeviceConstruct] = getattr(device, f"{metric_type.value}s")
 
             for construct in contructs:
                 if construct.alias in metric_names:
@@ -197,7 +197,7 @@ class MetricsReader:
                     metric=DeviceMetric(
                         name=filtered_constructs_by_id[point_id].alias,
                         device_kind=device.kind,
-                        construct_type=filtered_constructs_by_id[point_id].construct_type,
+                        metric_type=filtered_constructs_by_id[point_id].metric_type,
                     ),
                     device_name=device.name,
                     device_alias=device.alias,

--- a/atlas/metrics.py
+++ b/atlas/metrics.py
@@ -1,7 +1,7 @@
 import re
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -18,8 +18,8 @@ from atlas.models import (
 
 
 class Filter(BaseModel):
-    facilities: List[str]
-    metrics: List[DeviceMetric]
+    facilities: list[str]
+    metrics: list[DeviceMetric]
 
 
 class MetricValue(BaseModel):
@@ -32,7 +32,7 @@ class MetricValues(BaseModel):
     device_name: str
     device_alias: str
     aggregation: str
-    values: List[MetricValue]
+    values: list[MetricValue]
 
 
 class MetricsReader:
@@ -60,8 +60,8 @@ class MetricsReader:
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
         interval: int = 60,
-        aggregate_by: List[str] = ["avg"],
-    ) -> Dict[str, List[MetricValues]]:
+        aggregate_by: list[str] = ["avg"],
+    ) -> dict[str, list[MetricValues]]:
         """
         Retrieve metric values for a given filter and time range.
         Values are averaged over the sampling interval.
@@ -123,16 +123,16 @@ class MetricsReader:
 
         return result
 
-    def _get_devices(self, facility: Facility, agent_id: str) -> List[Device]:
+    def _get_devices(self, facility: Facility, agent_id: str) -> list[Device]:
         try:
             return self.client.list_devices(facility.organization_id, agent_id)
         except Exception as e:
             raise Exception(f"Error listing devices for facility {facility.display_name}: {e}")
 
     def _get_filtered_constructs_by_id(
-        self, device: Device, metrics: List[DeviceMetric]
-    ) -> List[Dict[str, ControlledDeviceConstruct]]:
-        result: Dict[str, ControlledDeviceConstruct] = {}
+        self, device: Device, metrics: list[DeviceMetric]
+    ) -> list[dict[str, ControlledDeviceConstruct]]:
+        result: dict[str, ControlledDeviceConstruct] = {}
         for metric_type in MetricType:
             # Extract metric names and regex patterns
             metric_names = {metric.name for metric in metrics if metric.metric_type == metric_type}
@@ -158,12 +158,12 @@ class MetricsReader:
         self,
         facility: Facility,
         agent_id: str,
-        point_ids: List[str],
+        point_ids: list[str],
         start: Optional[datetime],
         end: Optional[datetime],
         interval: int,
-        aggregate_by: List[str],
-    ) -> List[HistoricalValues]:
+        aggregate_by: list[str],
+    ) -> list[HistoricalValues]:
         try:
             return self.client.get_historical_values(
                 facility.organization_id, agent_id, point_ids, start, end, interval, aggregate_by
@@ -173,11 +173,11 @@ class MetricsReader:
 
     def _process_historical_values(
         self,
-        result: defaultdict[str, List[MetricValues]],
+        result: defaultdict[str, list[MetricValues]],
         facility: Facility,
         device: Device,
-        filtered_constructs_by_id: List[Dict[str, ControlledDeviceConstruct]],
-        hvalues: List[HistoricalValues],
+        filtered_constructs_by_id: list[dict[str, ControlledDeviceConstruct]],
+        hvalues: list[HistoricalValues],
     ) -> None:
         for agvalues in hvalues:
             point_id = agvalues.point_id

--- a/atlas/models.py
+++ b/atlas/models.py
@@ -85,9 +85,6 @@ class Setting(BaseModel):
     name: str
     kind: str
     unit: str | None = None
-    # value: float | bool | str | None = None
-    # default_value: float | bool | str | None = None
-    # desired_value: float | bool | str | None = None
 
     @property
     def alias(self) -> str:

--- a/atlas/models.py
+++ b/atlas/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Union
+from typing import Any, TypeAlias, Union
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -98,7 +98,7 @@ class Setting(BaseModel):
         return MetricType.setting
 
 
-ControlledDeviceConstruct = Union[
+ControlledDeviceConstruct: TypeAlias = Union[
     ControlPoint,
     Metric,
     Output,
@@ -230,7 +230,7 @@ def construct_from_metric_name(metric_name: str, device_kind: DeviceKind) -> Met
     return None
 
 
-DeviceMetricName = Union[CompressorMetric, CondenserMetric, EvaporatorMetric, VesselMetric]
+DeviceMetricName: TypeAlias = Union[CompressorMetric, CondenserMetric, EvaporatorMetric, VesselMetric]
 
 
 device_metric_mapping = {
@@ -249,7 +249,7 @@ class DeviceMetric(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def auto_fill_metric_type(cls, values):
+    def auto_fill_metric_type(cls, values: Any) -> dict[str, Any]:
         """
         Auto-fill metric_type based on device_kind and name if not provided.
         Only does lookup when name is provided (not when using alias_regex).

--- a/atlas/models.py
+++ b/atlas/models.py
@@ -108,6 +108,7 @@ class Device(BaseModel):
     id: str
     alias: str
     kind: str
+    name: str
     control_points: list[ControlPoint] = []
     metrics: list[Metric] = []
     outputs: list[Output] = []
@@ -115,10 +116,6 @@ class Device(BaseModel):
     settings: list[Setting] = []
     upstream: list[Connection] = []
     downstream: list[Connection] = []
-
-    @property
-    def name(self) -> str:
-        return self.alias
 
 
 class AnalogValues(BaseModel):

--- a/atlas/models.py
+++ b/atlas/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
-from enum import Enum
-from typing import Dict, List, Union
+from enum import StrEnum
+from typing import Union
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -16,7 +16,7 @@ class Facility(BaseModel):
     short_name: str
     address: str
     timezone: str
-    agents: List[Agent]
+    agents: list[Agent]
 
 
 class Connection(BaseModel):
@@ -25,11 +25,11 @@ class Connection(BaseModel):
 
 
 class DeviceAssociations(BaseModel):
-    upstream: List[Connection] = []
-    downstream: List[Connection] = []
+    upstream: list[Connection] = []
+    downstream: list[Connection] = []
 
 
-class MetricType(str, Enum):
+class MetricType(StrEnum):
     control_point = "control_point"
     metric = "metric"
     output = "output"
@@ -111,13 +111,13 @@ class Device(BaseModel):
     id: str
     alias: str
     kind: str
-    control_points: List[ControlPoint] = []
-    metrics: List[Metric] = []
-    outputs: List[Output] = []
-    conditions: List[Condition] = []
-    settings: List[Setting] = []
-    upstream: List[Connection] = []
-    downstream: List[Connection] = []
+    control_points: list[ControlPoint] = []
+    metrics: list[Metric] = []
+    outputs: list[Output] = []
+    conditions: list[Condition] = []
+    settings: list[Setting] = []
+    upstream: list[Connection] = []
+    downstream: list[Connection] = []
 
     @property
     def name(self) -> str:
@@ -125,13 +125,13 @@ class Device(BaseModel):
 
 
 class AnalogValues(BaseModel):
-    timestamps: List[int]
-    values: List[float]
+    timestamps: list[int]
+    values: list[float]
 
 
 class DiscreteValues(BaseModel):
-    timestamps: List[int]
-    values: List[bool]
+    timestamps: list[int]
+    values: list[bool]
 
 
 class PointValues(BaseModel):
@@ -139,7 +139,7 @@ class PointValues(BaseModel):
     discrete: DiscreteValues = None
 
 
-class AggregateBy(str, Enum):
+class AggregateBy(StrEnum):
     avg = "avg"
     min = "min"
     max = "max"
@@ -149,7 +149,7 @@ class AggregateBy(str, Enum):
 
 class HistoricalValues(BaseModel):
     point_id: str
-    values: Dict[AggregateBy, PointValues]
+    values: dict[AggregateBy, PointValues]
 
 
 class HourlyRate(BaseModel):
@@ -158,11 +158,11 @@ class HourlyRate(BaseModel):
 
 
 class HourlyRates(BaseModel):
-    usage_rate: List[HourlyRate] = []
-    maximum_demand_charge: List[HourlyRate] = []
-    time_of_use_demand_charge: List[HourlyRate] = []
-    day_ahead_market_rate: List[HourlyRate] = []
-    real_time_market_rate: List[HourlyRate] = []
+    usage_rate: list[HourlyRate] = []
+    maximum_demand_charge: list[HourlyRate] = []
+    time_of_use_demand_charge: list[HourlyRate] = []
+    day_ahead_market_rate: list[HourlyRate] = []
+    real_time_market_rate: list[HourlyRate] = []
 
 
 class HistoricalHourlyRate(BaseModel):
@@ -178,11 +178,11 @@ class HistoricalHourlyRate(BaseModel):
 
 
 class HistoricalHourlyRates(BaseModel):
-    usage_rate: List[HistoricalHourlyRate] = []
-    maximum_demand_charge: List[HistoricalHourlyRate] = []
-    time_of_use_demand_charge: List[HistoricalHourlyRate] = []
-    day_ahead_market_rate: List[HistoricalHourlyRate] = []
-    real_time_market_rate: List[HistoricalHourlyRate] = []
+    usage_rate: list[HistoricalHourlyRate] = []
+    maximum_demand_charge: list[HistoricalHourlyRate] = []
+    time_of_use_demand_charge: list[HistoricalHourlyRate] = []
+    day_ahead_market_rate: list[HistoricalHourlyRate] = []
+    real_time_market_rate: list[HistoricalHourlyRate] = []
 
     def to_hourly_rates(self) -> HourlyRates:
         return HourlyRates(
@@ -194,7 +194,7 @@ class HistoricalHourlyRates(BaseModel):
         )
 
 
-class DeviceKind(str, Enum):
+class DeviceKind(StrEnum):
     compressor = "compressor"
     evaporator = "evaporator"
     condenser = "condenser"
@@ -202,24 +202,24 @@ class DeviceKind(str, Enum):
     energy_meter = "energy meter"
 
 
-class CompressorMetric(str, Enum):
+class CompressorMetric(StrEnum):
     discharge_pressure = "DischargePressure"
     discharge_temperature = "DischargeTemperature"
     suction_pressure = "SuctionPressure"
     suction_temperature = "SuctionTemperature"
 
 
-class CondenserMetric(str, Enum):
+class CondenserMetric(StrEnum):
     discharge_pressure = "DischargePressure"
     discharge_temperature = "DischargeTemperature"
 
 
-class EvaporatorMetric(str, Enum):
+class EvaporatorMetric(StrEnum):
     supply_temperature = "SupplyTemperature"
     return_temperature = "ReturnTemperature"
 
 
-class VesselMetric(str, Enum):
+class VesselMetric(StrEnum):
     pressure = "Pressure"
 
 

--- a/examples/list_devices.py
+++ b/examples/list_devices.py
@@ -57,7 +57,7 @@ def list_devices(facilities: List[str], debug: bool = False) -> DeviceList:
 if __name__ == "__main__":
     json_output = "--json" in sys.argv
     debug = "--debug" in sys.argv
-    facilities = sys.argv[1:]
+    facilities = [arg for arg in sys.argv[1:] if not arg.startswith("--")]
 
     device_list = list_devices(facilities, debug)
     by_kind = device_list.by_kind

--- a/examples/read_metrics.py
+++ b/examples/read_metrics.py
@@ -5,7 +5,7 @@ import orjson
 from pydantic import BaseModel
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from atlas import CompressorMetric, DeviceKind, DeviceMetric, Filter, MetricsReader
+from atlas import CompressorMetric, ConstructType, DeviceKind, DeviceMetric, Filter, MetricsReader
 
 """
 This example retrieves the suction pressure and motor current for all
@@ -23,7 +23,9 @@ device_kind = DeviceKind.compressor
 metric_name = CompressorMetric.suction_pressure
 
 compressor_suction_pressure = DeviceMetric(device_kind=device_kind, name=metric_name)
-motor_current = DeviceMetric(device_kind=device_kind, alias_regex=".*_motorCurrent")
+motor_current = DeviceMetric(
+    device_kind=device_kind, construct_type=ConstructType.control_point, alias_regex=".*Current.*"
+)
 filter = Filter(facilities=facilities, metrics=[compressor_suction_pressure, motor_current])
 values = MetricsReader(debug=debug).read(filter)
 

--- a/examples/read_metrics.py
+++ b/examples/read_metrics.py
@@ -5,7 +5,7 @@ import orjson
 from pydantic import BaseModel
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from atlas import CompressorMetric, ConstructType, DeviceKind, DeviceMetric, Filter, MetricsReader
+from atlas import CompressorMetric, DeviceKind, DeviceMetric, Filter, MetricsReader, MetricType
 
 """
 This example retrieves the suction pressure and motor current for all
@@ -23,9 +23,7 @@ device_kind = DeviceKind.compressor
 metric_name = CompressorMetric.suction_pressure
 
 compressor_suction_pressure = DeviceMetric(device_kind=device_kind, name=metric_name)
-motor_current = DeviceMetric(
-    device_kind=device_kind, construct_type=ConstructType.control_point, alias_regex=".*Current.*"
-)
+motor_current = DeviceMetric(device_kind=device_kind, metric_type=MetricType.control_point, alias_regex=".*Current.*")
 filter = Filter(facilities=facilities, metrics=[compressor_suction_pressure, motor_current])
 values = MetricsReader(debug=debug).read(filter)
 

--- a/examples/read_metrics.py
+++ b/examples/read_metrics.py
@@ -14,7 +14,7 @@ average values for each minute.
 """
 json_output = "--json" in sys.argv
 debug = "--debug" in sys.argv
-facilities = sys.argv[1:]
+facilities = [arg for arg in sys.argv[1:] if not arg.startswith("--")]
 if not facilities:
     print("Usage: python read_metrics.py <facility1> <facility2> ...")
     sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlas-metrics"
-version = "0.0.3"
+version = "1.0.0"
 description = "Python API Client for retrieving metric point values from the Atlas platform."
 requires-python = ">=3.11"
 dependencies = ["httpx", "orjson", "pydantic", "requests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 httpx==0.27.0
 orjson==3.10.3
 pydantic==2.7.1
-requests==2.32.1
+requests==2.32.5


### PR DESCRIPTION
* Now supports new constructs on devices to differentiate between `control_points`, `settings`, `outputs`, `metrics`, and `conditions`. These are now on devices instead of the generic `properties`
* Removed `get_point_ids` endpoint from atlas client as point ids now exist on the devices themselves and do not need to be looked up via an API request
* Update examples to reflect changes
* Corrected the name on VesselMetric from `SuctionPressure` to `Pressure`
* List Devices example now supports facility filtering
* Update request dependency to `2.32.5`