### PR TITLE
add StructuredValues model

### DIFF
--- a/atlas/models.py
+++ b/atlas/models.py
@@ -128,9 +128,15 @@ class DiscreteValues(BaseModel):
     values: list[bool]
 
 
+class StructuredValues(BaseModel):
+    timestamps: list[int]
+    values: list[str]
+
+
 class PointValues(BaseModel):
     analog: AnalogValues = None
     discrete: DiscreteValues = None
+    structured: StructuredValues = None
 
 
 class AggregateBy(StrEnum):


### PR DESCRIPTION
A new `structured` (enum) type of data is available in the raw json response, but there is not yet a corresponding pydantic model in the SDK. Therefore, the data is not unpacked when calling HistoricalValues in the AtlasClient and is not returned to the user.

example of the raw json response that is being dropped when HistoricalValues is called: 
```
[{'point_id': 'xxxxxx', 'values': {'first': {'structured': {'timestamps': [1762181760, ...], 'values': ['Automatic', ...]}]
```

This PR adds a `StructuredValues` model, which expects a list of string values, and adds the model to the PointValues class so that HistoricalValues is able to treat `structured` data in the same way as `analog` and `discrete` values