### PR TITLE
Fix bug in metrics id to construct map

### DIFF
--- a/atlas/metrics.py
+++ b/atlas/metrics.py
@@ -317,7 +317,7 @@ class MetricsReader:
                 grouped[group_key]["values"].append(
                     MetricValue(
                         timestamp=timestamp,
-                        value=res.numberValue.scaled if res.numberValue else float('nan'),
+                        value=res.numberValue.scaled if res.numberValue else None,
                     )
                 )
         

--- a/atlas/metrics.py
+++ b/atlas/metrics.py
@@ -152,7 +152,7 @@ class MetricsReader:
                 filtered_constructs_by_id.update(new_filtered_constructs_by_id)
 
                 agg_enums = [AggregateBy(a) for a in aggregate_by]
-                for construct_id, construct in filtered_constructs_by_id.items():
+                for construct_id, construct in new_filtered_constructs_by_id.items():
                     construct_id_to_device_id[construct_id] = device.id
                     if construct.metric_type == MetricType.setting:
                         source = HistoricalSettingQuerySource(setting_id=construct_id)
@@ -317,7 +317,7 @@ class MetricsReader:
                 grouped[group_key]["values"].append(
                     MetricValue(
                         timestamp=timestamp,
-                        value=res.numberValue.scaled if res.numberValue else None,
+                        value=res.numberValue.scaled if res.numberValue else float('nan'),
                     )
                 )
         


### PR DESCRIPTION
fixes #16 

There was a bug with the map of point ids to narrative constructs where the linked device kept being overwritten. This PR fixes the issue. 