### PR TITLE
Add Code Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require code owner approval for all changes
+* @nicolo @Bkleinwort @austinhuck @raphael


### PR DESCRIPTION
Add a CODEOWNERS file to use as a list of approved PR reviews. A follow on to this PR will be to require approval from someone in this file in order to merge.