### PR TITLE
APP-374: Add Griffe API check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
     types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   GIT_CONFIG_COUNT: 2
@@ -77,3 +85,119 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           ruff format --check --diff ${{ steps.changed-files.outputs.all_changed_files }}
+
+  api-compatibility:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          pip install "griffe~=2.1.0"
+
+      - name: Generate report
+        id: generate-report
+        run: |
+          if griffe check atlas --search . --against origin/main --verbose > "$RUNNER_TEMP/griffe-report.txt" 2>&1; then
+            echo "No public API changes detected."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            cat "$RUNNER_TEMP/griffe-report.txt"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Annotate pull request files
+        if: steps.generate-report.outputs.changed == 'true'
+        run: |
+          griffe check atlas --search . --against origin/main --format github > "$RUNNER_TEMP/griffe-annotations.txt" 2>&1 || true
+          sed -E 's/(::warning file=[^,]+,line=)0(,title=)/\11\2/' "$RUNNER_TEMP/griffe-annotations.txt"
+
+      - name: Build summary
+        env:
+          API_CHANGED: ${{ steps.generate-report.outputs.changed }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          BASE_URL="https://github.com/${REPO}/blob/${HEAD_SHA}"
+          # Turn leading "path:line:" references into Markdown links to the file at that line.
+          # Module-level findings use line 0; link those to the top of the file with no anchor.
+          link_report() {
+            sed -E \
+              -e "s|^([^[:space:]:]+):([1-9][0-9]*): |[\1:\2](${BASE_URL}/\1#L\2): |" \
+              -e "s|^([^[:space:]:]+):0: |[\1](${BASE_URL}/\1): |" \
+              "$RUNNER_TEMP/griffe-report.txt"
+          }
+          {
+            echo "<!-- griffe-api-check-report -->"
+            echo "## Public API Breaking Changes"
+            if [ "$API_CHANGED" = "true" ]; then
+              echo ":warning: Breaking changes detected"
+              echo
+              link_report
+              echo
+            else
+              echo ":white_check_mark: No breaking changes detected"
+            fi
+            echo
+            echo "---"
+            echo
+            echo "Griffe checked the public API surface for breaking changes against \`origin/main\`."
+            echo
+            echo "> [!NOTE]"
+            echo "> Griffe does not analyze or report on runtime behavior or semantic changes."
+            echo "> "
+            echo "> This report is informational and will not block merging."
+            echo
+          } > "$RUNNER_TEMP/griffe-summary.md"
+
+      - name: Publish summary
+        run: cat "$RUNNER_TEMP/griffe-summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment summary on PR
+        if: github.event.pull_request.head.repo.fork == false
+        uses: actions/github-script@v8
+        env:
+          GRIFFE_SUMMARY: ${{ runner.temp }}/griffe-summary.md
+        with:
+          script: |
+            const fs = require("fs");
+
+            const marker = "<!-- griffe-api-check-report -->";
+            const body = fs.readFileSync(process.env.GRIFFE_SUMMARY, "utf8");
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existingComment = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -302,6 +302,18 @@ Mypy is used to perform static type checking on the source code. The Mypy check 
 mypy
 ```
 
+### API Changes Detection
+
+[Griffe](https://github.com/mkdocstrings/griffe) checks the public API surface for breaking changes against a baseline branch. This is used to monitor SemVer compliance on release and identify potentially breaking changes before they are merged.
+
+The pull request CI pipeline runs Griffe and publishes a detailed summary. This check is intentionally non-blocking: it reports API changes but never prevents a merge, leaving final design and compatibility decisions to the developer and reviewers.
+
+Griffe can be run to check the atlas package against a branch or git ref.
+
+```bash
+griffe check atlas --search . --against origin/main
+```
+
 ## License
 
 This project is licensed under the MIT License. See the LICENSE file for details.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ types-requests
 pytest
 ruff
 mypy
+griffe~=2.1.0


### PR DESCRIPTION
## Issue

Closes APP-374

## Description

Adds [Griffe](https://mkdocstrings.github.io/griffe/) (/ɡʁif/) to the pull request CI workflow to check for breaking changes in the public API surface.

## Key Changes

- A breaking changes report comment is automatically added and updated on the PR
- Annotation warnings show inline on the "Files changed" diff view

## Testing

- Non-breaking change CI run and comment on this PR
- #25 to demonstrate and test breaking change CI, comment on PR, and diff check annotations