### PR TITLE
APP-394: Pytest setup with coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   GIT_CONFIG_VALUE_0: https://github.com
   GIT_CONFIG_KEY_1: url.https://crossnokaye-robot:${{ secrets.ROBOT_TOKEN }}@github.com.insteadOf
   GIT_CONFIG_VALUE_1: ssh://git@github.com
-  PYTHON_VERSION: "3.11"
+  PYTHON_MIN_VERSION: "3.11"
 
 jobs:
   type-check:
@@ -32,11 +32,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
+          python-version: ${{ env.PYTHON_MIN_VERSION }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -r requirements.txt --group dev
 
       - name: Cache Mypy
         uses: actions/cache@v5
@@ -50,6 +53,7 @@ jobs:
 
       - name: Run Mypy
         run: mypy
+
   linting:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -68,12 +72,15 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.PYTHON_MIN_VERSION }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
 
       - name: Install dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
-          pip install ruff
+        run: pip install -r requirements.txt --group dev
 
       - name: Run ruff check
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -85,6 +92,54 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           ruff format --check --diff ${{ steps.changed-files.outputs.all_changed_files }}
+
+  test:
+    name: test (python ${{ matrix.python-version }}, ${{ matrix.deps }} dependencies)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { python-version: "3.11", deps: min }
+          - { python-version: "3.12", deps: min }
+          - { python-version: "3.13", deps: min }
+          - { python-version: "3.14", deps: min }
+          - { python-version: "3.11", deps: latest }
+          - { python-version: "3.14", deps: latest }
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
+
+      - name: Install dependencies (min)
+        if: matrix.deps == 'min'
+        run: pip install -r requirements.txt --group dev
+
+      - name: Install dependencies (latest)
+        if: matrix.deps == 'latest'
+        run: pip install . --group dev
+
+      - name: Log resolved versions
+        run: pip freeze | sort
+
+      - name: Run Unit Tests
+        run: pytest --cov=atlas --cov-report=xml:coverage-unit.xml
+
+      - name: Upload Unit Test Coverage
+        if: matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min'
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-unit.xml
+          flags: unit-tests
 
   api-compatibility:
     if: github.event_name == 'pull_request'
@@ -101,11 +156,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.PYTHON_MIN_VERSION }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
 
       - name: Install dependencies
-        run: |
-          pip install "griffe~=2.1.0"
+        run: pip install -r requirements.txt --group dev
 
       - name: Generate report
         id: generate-report

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .venv/
 .ruff_cache/
 .mypy_cache/
+/.coverage
 
 # Ignore .DS_Store files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ simplifies usage, while the low-level API offers more flexibility and control.
     cd atlas-metrics-sdk
     ```
 
-2. Create a virtual environment and install the dependencies:
+2. Create a virtual environment and install the library and dependencies:
 
     ```bash
     python3 -m venv .venv
@@ -264,12 +264,12 @@ Contributions are welcome! Please submit a pull request or open an issue to disc
 
 ### Environment Setup
 
-Follow setup in [Installation](#installation), but when creating a virtual environment, install the dev dependencies:
+Create a virtual environment and install the library as editable and install dev dependencies:
 
  ```bash
  python3 -m venv .venv
  source .venv/bin/activate
- pip install -r requirements-dev.txt
+ pip install -e . --group dev
  ```
 
 ### Linting
@@ -301,6 +301,21 @@ Mypy is used to perform static type checking on the source code. The Mypy check 
 ```bash
 mypy
 ```
+
+### Testing
+
+Pytest is used to run the test suite. The test suite is required to pass before
+merging a pull request. Coverage is calculated and reported with pytest-cov.
+
+```bash
+pytest --cov=atlas
+```
+
+CI runs tests across Python **3.11–3.14** with two dependency profiles: **min**
+installs the pinned floor from `requirements.txt`; **max** installs the latest
+compatible releases within the bounds declared in `pyproject.toml`. Local
+development typically uses `pip install -e . --group dev`, which is editable and
+not identical to the CI min install.
 
 ### API Changes Detection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
 ]
 
 [tool.coverage.run]
+branch = true
 source = ["atlas"]
 
 [tool.coverage.paths]
@@ -43,6 +44,9 @@ files = ["atlas", "examples", "tests"]
 strict = true
 warn_unreachable = true
 explicit_package_bases = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ name = "atlas-metrics"
 version = "1.0.0"
 description = "Python API Client for retrieving metric point values from the Atlas platform."
 requires-python = ">=3.11"
-dependencies = ["httpx", "orjson", "pydantic", "requests"]
+dependencies = [
+    "orjson>=3.11.1",
+    "pydantic>=2.12.4,<3.0.0",
+    "requests>=2.32.5",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,25 @@ description = "Python API Client for retrieving metric point values from the Atl
 requires-python = ">=3.11"
 dependencies = ["httpx", "orjson", "pydantic", "requests"]
 
+[dependency-groups]
+dev = [
+    "types-requests<2.34.0.0",  # The 'requests' package includes type annotations and stubs since version 2.34.0
+    "pytest==9.1.*",
+    "pytest-cov==7.1.*",
+    "ruff==0.15.*",
+    "mypy==2.2.*",
+    "griffe==2.1.*",
+]
+
+[tool.coverage.run]
+source = ["atlas"]
+
+[tool.coverage.paths]
+source = [
+    "atlas",
+    "*/site-packages/atlas_metrics",
+]
+
 [tool.hatch.build.targets.sdist]
 exclude = ["/examples"]
 
@@ -16,7 +35,7 @@ exclude = ["/examples"]
 packages = ["atlas"]
 
 [tool.mypy]
-files = ["atlas", "examples"]
+files = ["atlas", "examples", "tests"]
 strict = true
 warn_unreachable = true
 explicit_package_bases = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
--r requirements.txt
-types-requests
-pytest
-ruff
-mypy
-griffe~=2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 httpx==0.27.0
 orjson==3.10.3
 pydantic==2.7.1
+.
 requests==2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-httpx==0.27.0
-orjson==3.10.3
-pydantic==2.7.1
 .
+orjson==3.11.1
+pydantic==2.12.4
 requests==2.32.5

--- a/tests/test_time_helpers.py
+++ b/tests/test_time_helpers.py
@@ -1,0 +1,5 @@
+from atlas.time_helpers import parse_dt
+
+
+def test_parse_dt_none_returns_none() -> None:
+    assert parse_dt(None) is None


### PR DESCRIPTION
## Issue

Closes APP-394

## Description

Adds support for running pytest and CI matrix pytest jobs with Codecov upload.

## Key Changes

- Rework dependency management
  - Remove unused httpx dependency
  - Add dependency version constraints in `pyproject.toml `
  - Update dependencies to minimum versions compatible with python 3.13 and 3.14 (support for 3.13 and 3.14 was broken when installing minimum dependency versions, see [actions run](https://github.com/crossnokaye/atlas-metrics-sdk/actions/runs/29107398454))
  - Add dev dependency group to` pyproject.toml` and remove requirements-dev.txt, dev requirements now installable with `--group dev`
  - Revised `requirements.txt` to install the library package `.`, standard practice for library code
- pytest configuration and added single test as baseline
- pytest-cov and Codecov configuration
- Update README.md accordingly 

## Testing

- Pytest runs local with README.md instructions
- test matrix job running successfully in CI

## Follow Up

- [x] Configure Codecov and add Codecov repo secret