### PR TITLE
APP-394: Fix codecov CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,21 +139,23 @@ jobs:
         run: pytest --cov --cov-report=xml:coverage-unit.xml --junitxml=junit-unit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov
-        if: always() && matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min' && hashFiles('coverage-unit.xml') != ''
+        if: ${{ !cancelled() && matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min' && hashFiles('coverage-unit.xml') != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
           files: ./coverage-unit.xml
           flags: unit-tests
           report_type: coverage
       - name: Upload test results to Codecov
-        if: always() && matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min' && hashFiles('junit-unit.xml') != ''
+        if: ${{ !cancelled() && matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min' && hashFiles('junit-unit.xml') != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
           files: ./junit-unit.xml
           flags: unit-tests
-          report-type: test_results
+          report_type: test_results
 
   api-compatibility:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,21 +125,35 @@ jobs:
 
       - name: Install dependencies (latest)
         if: matrix.deps == 'latest'
-        run: pip install . --group dev
+        run: pip install -e . --group dev
 
       - name: Log resolved versions
         run: pip freeze | sort
 
-      - name: Run Unit Tests
-        run: pytest --cov=atlas --cov-report=xml:coverage-unit.xml
+      - name: Run unit tests
+        if: ${{!(matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min')}}
+        run: pytest
 
-      - name: Upload Unit Test Coverage
+      - name: Run unit tests with coverage
         if: matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min'
+        run: pytest --cov --cov-report=xml:coverage-unit.xml --junitxml=junit-unit.xml -o junit_family=legacy
+
+      - name: Upload coverage to Codecov
+        if: always() && matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min' && hashFiles('coverage-unit.xml') != ''
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-unit.xml
           flags: unit-tests
+          report_type: coverage
+      - name: Upload test results to Codecov
+        if: always() && matrix.python-version == env.PYTHON_MIN_VERSION && matrix.deps == 'min' && hashFiles('junit-unit.xml') != ''
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit-unit.xml
+          flags: unit-tests
+          report-type: test_results
 
   api-compatibility:
     if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 .ruff_cache/
 .mypy_cache/
 /.coverage
+/coverage-*.xml
+/junit-*.xml
 
 # Ignore .DS_Store files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -312,10 +312,10 @@ pytest --cov=atlas
 ```
 
 CI runs tests across Python **3.11–3.14** with two dependency profiles: **min**
-installs the pinned floor from `requirements.txt`; **max** installs the latest
+installs the pinned floor from `requirements.txt`; **latest** installs the latest
 compatible releases within the bounds declared in `pyproject.toml`. Local
 development typically uses `pip install -e . --group dev`, which is editable and
-not identical to the CI min install.
+not identical to the CI install.
 
 ### API Changes Detection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,6 @@ dev = [
 branch = true
 source = ["atlas"]
 
-[tool.coverage.paths]
-source = [
-    "atlas",
-    "*/site-packages/atlas_metrics",
-]
-
 [tool.hatch.build.targets.sdist]
 exclude = ["/examples"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-.
+-e .
 orjson==3.11.1
 pydantic==2.12.4
 requests==2.32.5


### PR DESCRIPTION
## Issue

Closes APP-394

## Description

Fixes up Codecov CI setup as coverage was not being calculated and uploaded properly.

## Key Changes
- Correctly calculate coverage using editable package install (ensures coverage paths can be correlated to source without extra shadowing config)
- Ensures pytest coverage is only calculated and uploaded for one matrix test (3.11 min dependencies)
- Adds test report (junit format) generation and upload to Codecov
- Improves uploads to not search and only uploaded specified files


## Testing

- CI executing correctly
- Codecov has reports and commented on PR