### PR TITLE
APP-395: Initial unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dev = [
     "types-requests<2.34.0.0",  # The 'requests' package includes type annotations and stubs since version 2.34.0
     "pytest==9.1.*",
     "pytest-mock==3.15.*",
+    "requests-mock==1.10.*",
+    "pyfakefs==6.1.*",
     "pytest-cov==7.1.*",
     "ruff==0.15.*",
     "mypy==2.2.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 dev = [
     "types-requests<2.34.0.0",  # The 'requests' package includes type annotations and stubs since version 2.34.0
     "pytest==9.1.*",
+    "pytest-mock==3.15.*",
     "pytest-cov==7.1.*",
     "ruff==0.15.*",
     "mypy==2.2.*",

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -11,9 +11,15 @@ from atlas.models import Agent, Facility
 
 
 @pytest.fixture
-def mock_http_client(mocker: MockerFixture) -> Mock:
+def mock_http_client_cls(mocker: MockerFixture) -> Mock:
+    mock_http_client_cls = mocker.patch("atlas.atlas_client.AtlasHTTPClient")
+    return mock_http_client_cls
+
+
+@pytest.fixture
+def mock_http_client(mock_http_client_cls: Mock) -> Mock:
     mock_http_client = cast(Mock, create_autospec(AtlasHTTPClient, spec_set=True, instance=True))
-    mocker.patch("atlas.atlas_client.AtlasHTTPClient", return_value=mock_http_client)
+    mock_http_client_cls.return_value = mock_http_client
     return mock_http_client
 
 
@@ -22,10 +28,7 @@ def client(mock_http_client: Mock) -> AtlasClient:
     return AtlasClient()
 
 
-def test_atlas_client_init_relays_args_and_refresh_auth(mocker: MockerFixture) -> None:
-    mock_http_client = create_autospec(AtlasHTTPClient, spec_set=True, instance=True)
-    mock_http_client_cls = mocker.patch("atlas.atlas_client.AtlasHTTPClient", return_value=mock_http_client)
-
+def test_atlas_client_init_relays_args_and_refresh_auth(mock_http_client_cls: Mock, mock_http_client: Mock) -> None:
     client = AtlasClient(refresh_token="test-token", debug=True)
 
     assert client

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -1,0 +1,84 @@
+from typing import cast
+from unittest.mock import Mock, create_autospec
+
+import pytest
+from pydantic import ValidationError
+from pytest_mock import MockerFixture
+
+from atlas.atlas_client import AtlasClient
+from atlas.http_client import AtlasHTTPClient, AtlasHTTPError
+from atlas.models import Agent, Facility
+
+
+@pytest.fixture
+def mock_http_client(mocker: MockerFixture) -> Mock:
+    mock_http_client = cast(Mock, create_autospec(AtlasHTTPClient, spec_set=True, instance=True))
+    mocker.patch("atlas.atlas_client.AtlasHTTPClient", return_value=mock_http_client)
+    return mock_http_client
+
+
+@pytest.fixture
+def client(mock_http_client: Mock) -> AtlasClient:
+    return AtlasClient()
+
+
+def test_atlas_client_init_relays_args_and_refresh_auth(mocker: MockerFixture) -> None:
+    mock_http_client = create_autospec(AtlasHTTPClient, spec_set=True, instance=True)
+    mock_http_client_cls = mocker.patch("atlas.atlas_client.AtlasHTTPClient", return_value=mock_http_client)
+
+    client = AtlasClient(refresh_token="test-token", debug=True)
+
+    assert client
+    mock_http_client_cls.assert_called_once_with(refresh_token="test-token", debug=True)
+    mock_http_client.refresh_access_token.assert_called_once()
+
+
+def test_atlas_client_list_facilities_parses_and_returns(mock_http_client: Mock, client: AtlasClient) -> None:
+    expected_facility = Facility(
+        organization_id="org-1",
+        facility_id="fac-1",
+        display_name="Test Facility",
+        short_name="test",
+        address="123 Main St",
+        timezone="America/New_York",
+        agents=[Agent(agent_id="agent-1")],
+    )
+    mock_http_client.get_user_id.return_value = "user-123"
+    mock_http_client.request.return_value.status_code = 200
+    mock_http_client.request.return_value.json.return_value = [
+        expected_facility.model_dump(mode="json"),
+    ]
+
+    got_facilities = client.list_facilities()
+
+    mock_http_client.request.assert_called_once_with("GET", "/users/user-123/facilities?view=extended")
+    assert got_facilities == [expected_facility]
+
+
+def test_atlas_client_list_facilities_value_error_raises_http_error(
+    mock_http_client: Mock,
+    client: AtlasClient,
+) -> None:
+    mock_http_client.get_user_id.return_value = "user-123"
+    mock_http_client.request.return_value.status_code = 200
+    mock_http_client.request.return_value.json.side_effect = ValueError("test error")
+
+    with pytest.raises(AtlasHTTPError, match="test error") as exc_info:
+        _ = client.list_facilities()
+
+    assert exc_info.value.response.status_code == 200
+
+
+def test_atlas_client_list_facilities_pydantic_error_raises(mock_http_client: Mock, client: AtlasClient) -> None:
+    mock_http_client.get_user_id.return_value = "user-123"
+    mock_http_client.request.return_value.status_code = 200
+    mock_http_client.request.return_value.json.return_value = [
+        {
+            "organization_id": "org-1",
+            "facility_id": "fac-1",
+            "bad_field": "test",
+        },
+    ]
+
+    with pytest.raises(ValidationError, match="bad_field"):
+        _ = client.list_facilities()

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -111,6 +111,8 @@ def test_http_client_request_404_raises(
 
     with pytest.raises(AtlasHTTPError, match="Test Not Found") as ex_res:
         _ = client.request("GET", "/missing")
-        assert ex_res.value.response
-        assert ex_res.value.response.status_code == 404
-        assert ex_res.value.response.text == "Test Not Found"
+
+    assert ex_res.value is not None
+    assert ex_res.value.response is not None
+    assert ex_res.value.response.status_code == 404
+    assert ex_res.value.response.text == "Test Not Found"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+import pytest
+from pyfakefs.fake_filesystem import FakeFilesystem
+from requests_mock import Mocker
+
+from atlas.http_client import AtlasHTTPClient, AtlasHTTPError
+
+LOGIN_URL = "https://atlaslive.io/api/login/v3/login"
+USERINFO_URL = "https://atlaslive.io/api/login/v3/userinfo"
+USER = "user-123"
+MOCK_REFRESH_TOKEN = "mock-refresh-token"
+MOCK_ACCESS_TOKEN = "mock-access-token"
+
+
+@pytest.fixture
+def client(requests_mock: Mocker) -> AtlasHTTPClient:
+    requests_mock.post(
+        LOGIN_URL,
+        json={"access_token": MOCK_ACCESS_TOKEN, "expires_in": 3600},
+    )
+    requests_mock.get(USERINFO_URL, json={"sub": USER})
+
+    client = AtlasHTTPClient(refresh_token=MOCK_REFRESH_TOKEN)
+    client.refresh_access_token()
+
+    return client
+
+
+def test_http_client_init_uses_refresh_token_arg(
+    requests_mock: Mocker,
+    monkeypatch: pytest.MonkeyPatch,
+    fs: FakeFilesystem,
+) -> None:
+    monkeypatch.setenv("ATLAS_REFRESH_TOKEN", "token-from-env")
+    fs.create_file(
+        file_path=Path.home() / ".config/atlas/config.toml",
+        contents='[production]\nrefresh_token = "token-from-file"',
+    )
+    requests_mock.post(
+        LOGIN_URL,
+        additional_matcher=lambda r: r.text == "grant_type=refresh_token&refresh_token=token-from-args",
+        json={"access_token": "test-access-token", "expires_in": 3600},
+    )
+    requests_mock.get(USERINFO_URL, json={"sub": "use-123"})
+
+    client = AtlasHTTPClient(refresh_token="token-from-args")
+    client.refresh_access_token()
+
+
+def test_http_client_init_no_args_reads_refresh_token_from_env(
+    requests_mock: Mocker,
+    monkeypatch: pytest.MonkeyPatch,
+    fs: FakeFilesystem,
+) -> None:
+    monkeypatch.setenv("ATLAS_REFRESH_TOKEN", "token-from-env")
+    fs.create_file(
+        file_path=Path.home() / ".config/atlas/config.toml",
+        contents='[production]\nrefresh_token = "token-from-file"',
+    )
+    requests_mock.post(
+        LOGIN_URL,
+        additional_matcher=lambda r: r.text == "grant_type=refresh_token&refresh_token=token-from-env",
+        json={"access_token": "test-access-token", "expires_in": 3600},
+    )
+    requests_mock.get(USERINFO_URL, json={"sub": "use-123"})
+
+    client = AtlasHTTPClient()
+    client.refresh_access_token()
+
+
+def test_http_client_init_no_args_reads_refresh_token_from_file(requests_mock: Mocker, fs: FakeFilesystem) -> None:
+    fs.create_file(
+        file_path=Path.home() / ".config/atlas/config.toml",
+        contents='[production]\nrefresh_token = "token-from-file"',
+    )
+    requests_mock.post(
+        LOGIN_URL,
+        additional_matcher=lambda r: r.text == "grant_type=refresh_token&refresh_token=token-from-file",
+        json={"access_token": "test-access-token", "expires_in": 3600},
+    )
+    requests_mock.get(USERINFO_URL, json={"sub": "use-123"})
+
+    client = AtlasHTTPClient()
+    client.refresh_access_token()
+
+
+def test_http_client_request_builds_url_and_sends_authorization_header(
+    requests_mock: Mocker,
+    client: AtlasHTTPClient,
+) -> None:
+    requests_mock.get(
+        "https://atlaslive.io/api/front/v1/resource",
+        additional_matcher=lambda r: r.headers.get("Authorization") == f"Bearer {MOCK_ACCESS_TOKEN}",
+        json={"res": "test"},
+    )
+
+    res = client.request("GET", "/resource")
+    assert res.json() == {"res": "test"}
+
+
+def test_http_client_request_404_raises(
+    requests_mock: Mocker,
+    client: AtlasHTTPClient,
+) -> None:
+    requests_mock.get(
+        "https://atlaslive.io/api/front/v1/missing",
+        status_code=404,
+        text="Test Not Found",
+    )
+
+    with pytest.raises(AtlasHTTPError, match="Test Not Found") as ex_res:
+        _ = client.request("GET", "/missing")
+        assert ex_res.value.response
+        assert ex_res.value.response.status_code == 404
+        assert ex_res.value.response.text == "Test Not Found"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,465 @@
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from atlas.models import (
+    AggregateBy,
+    CompressorMetric,
+    CondenserMetric,
+    Condition,
+    Connection,
+    ControlPoint,
+    DeviceAssociations,
+    DeviceKind,
+    DeviceMetric,
+    EvaporatorMetric,
+    HistoricalHourlyRate,
+    HistoricalHourlyRates,
+    HistoricalReadingQuery,
+    HistoricalSettingQuery,
+    HistoricalSettingQuerySource,
+    HourlyRate,
+    Metric,
+    MetricType,
+    Output,
+    Setting,
+    SettingResultSequenceValueItem,
+    VesselMetric,
+    construct_from_metric_name,
+    is_valid_metric,
+)
+
+
+@pytest.mark.parametrize(
+    ("device_kind", "metric_name", "expected"),
+    [
+        pytest.param(
+            DeviceKind.compressor,
+            CompressorMetric.suction_pressure.value,
+            MetricType.control_point,
+            id="compressor_suction_pressure",
+        ),
+        pytest.param(
+            DeviceKind.compressor,
+            CompressorMetric.discharge_pressure.value,
+            MetricType.control_point,
+            id="compressor_discharge_pressure",
+        ),
+        pytest.param(
+            DeviceKind.condenser,
+            CondenserMetric.discharge_pressure.value,
+            MetricType.control_point,
+            id="condenser_discharge_pressure",
+        ),
+        pytest.param(
+            DeviceKind.evaporator,
+            EvaporatorMetric.supply_temperature.value,
+            MetricType.control_point,
+            id="evaporator_supply_temperature",
+        ),
+        pytest.param(
+            DeviceKind.vessel,
+            VesselMetric.pressure.value,
+            MetricType.control_point,
+            id="vessel_pressure",
+        ),
+        pytest.param(
+            DeviceKind.compressor,
+            "NotARealMetric",
+            None,
+            id="unknown_metric",
+        ),
+    ],
+)
+def test_construct_from_metric_name_with_name_returns_type(
+    device_kind: DeviceKind,
+    metric_name: str,
+    expected: MetricType | None,
+) -> None:
+    result = construct_from_metric_name(metric_name, device_kind)
+
+    assert result == expected
+
+
+def test_construct_from_metric_name_with_unmapped_kind_raises_key_error() -> None:
+    with pytest.raises(KeyError):
+        construct_from_metric_name("DischargePressure", DeviceKind.energy_meter)
+
+
+def test_control_point_with_payload_parses_id_and_unit() -> None:
+    control_point = ControlPoint.model_validate(
+        {
+            "control_point_id": "cp-1",
+            "alias": "SuctionPressure",
+            "bias": "direct",
+            "type": "analog",
+            "unit": "psi",
+        },
+    )
+
+    assert control_point.id == "cp-1"
+    assert control_point.unit == "psi"
+
+
+def test_device_associations_with_default_upstream_isolates_lists() -> None:
+    associations_a = DeviceAssociations()
+    associations_b = DeviceAssociations()
+
+    associations_a.upstream.append(Connection(device_id="device-1", kind="upstream"))
+
+    assert associations_b.upstream == []
+    assert associations_a.downstream == []
+
+
+def test_device_metric_with_alias_regex_and_type_succeeds() -> None:
+    metric = DeviceMetric.model_validate(
+        {
+            "device_kind": DeviceKind.compressor,
+            "alias_regex": ".*Current.*",
+            "metric_type": MetricType.control_point,
+        },
+    )
+
+    assert metric.alias_regex == ".*Current.*"
+    assert metric.metric_type == MetricType.control_point
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            {"device_kind": DeviceKind.compressor, "alias_regex": ".*Current.*"},
+            id="missing_metric_type",
+        ),
+        pytest.param(
+            {"device_kind": DeviceKind.compressor, "name": "", "alias_regex": ".*Current.*"},
+            id="empty_name",
+        ),
+    ],
+)
+def test_device_metric_with_alias_regex_without_type_raises_validation_error(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="metric_type must be provided when using alias_regex"):
+        DeviceMetric.model_validate(payload)
+
+
+def test_device_metric_with_explicit_type_uses_override() -> None:
+    metric = DeviceMetric.model_validate(
+        {
+            "device_kind": DeviceKind.compressor,
+            "name": CompressorMetric.suction_pressure.value,
+            "metric_type": MetricType.metric,
+        },
+    )
+
+    assert metric.metric_type == MetricType.metric
+
+
+@pytest.mark.parametrize(
+    ("device_kind", "metric_name"),
+    [
+        pytest.param(DeviceKind.compressor, CompressorMetric.suction_pressure.value, id="compressor"),
+        pytest.param(DeviceKind.condenser, CondenserMetric.discharge_pressure.value, id="condenser"),
+        pytest.param(DeviceKind.evaporator, EvaporatorMetric.supply_temperature.value, id="evaporator"),
+        pytest.param(DeviceKind.vessel, VesselMetric.pressure.value, id="vessel"),
+    ],
+)
+def test_device_metric_with_known_name_sets_metric_type(device_kind: DeviceKind, metric_name: str) -> None:
+    metric = DeviceMetric.model_validate({"device_kind": device_kind, "name": metric_name})
+
+    assert metric.metric_type == MetricType.control_point
+
+
+def test_device_metric_with_unmapped_kind_raises_key_error() -> None:
+    with pytest.raises(KeyError):
+        DeviceMetric.model_validate(
+            {
+                "device_kind": DeviceKind.energy_meter,
+                "name": CompressorMetric.suction_pressure.value,
+            },
+        )
+
+
+def test_device_metric_with_unknown_name_raises_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        DeviceMetric.model_validate({"device_kind": DeviceKind.compressor, "name": "UnknownMetric"})
+
+
+def test_historical_hourly_rate_start_datetime_returns_utc() -> None:
+    timestamp = 1_704_067_200
+    historical_rate = HistoricalHourlyRate(start=timestamp, rate=0.12)
+
+    assert historical_rate.start_datetime == datetime.fromtimestamp(timestamp, tz=UTC)
+
+
+def test_historical_hourly_rate_to_hourly_rate_returns_rate() -> None:
+    timestamp = 1_704_067_200
+    historical_rate = HistoricalHourlyRate(start=timestamp, rate=0.12)
+
+    hourly_rate = historical_rate.to_hourly_rate()
+
+    assert hourly_rate == HourlyRate(start=historical_rate.start_datetime, rate=0.12)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "timestamp", "rate"),
+    [
+        pytest.param("usage_rate", 1_704_067_200, 0.12, id="usage_rate"),
+        pytest.param("maximum_demand_charge", 1_704_070_800, 5.0, id="maximum_demand_charge"),
+        pytest.param("time_of_use_demand_charge", 1_704_074_400, 3.0, id="time_of_use_demand_charge"),
+        pytest.param("day_ahead_market_rate", 1_704_078_000, 1.0, id="day_ahead_market_rate"),
+        pytest.param("real_time_market_rate", 1_704_081_600, 2.0, id="real_time_market_rate"),
+    ],
+)
+def test_historical_hourly_rates_to_hourly_rates_converts_each_field(
+    field_name: str,
+    timestamp: int,
+    rate: float,
+) -> None:
+    historical_rate = HistoricalHourlyRate(start=timestamp, rate=rate)
+    historical_rates = HistoricalHourlyRates(**{field_name: [historical_rate]})
+
+    hourly_rates = historical_rates.to_hourly_rates()
+    converted = getattr(hourly_rates, field_name)
+
+    assert len(converted) == 1
+    assert converted[0].rate == rate
+    assert converted[0].start == datetime.fromtimestamp(timestamp, tz=UTC)
+
+
+def test_historical_reading_query_with_default_aggregate_by_isolates_lists() -> None:
+    query_a = HistoricalReadingQuery(source_id="metric-a", aggregate_by=[AggregateBy.avg])
+    query_b = HistoricalReadingQuery(source_id="metric-b")
+
+    query_a.aggregate_by.append(AggregateBy.max)
+
+    assert query_b.aggregate_by == []
+
+
+@pytest.mark.parametrize(
+    "source_id",
+    [
+        pytest.param("", id="empty_string"),
+        pytest.param("   ", id="whitespace_only"),
+    ],
+)
+def test_historical_reading_query_with_invalid_source_id_raises_validation_error(source_id: str) -> None:
+    with pytest.raises(ValidationError, match="source_id must be a non-empty string"):
+        HistoricalReadingQuery(source_id=source_id)
+
+
+@pytest.mark.parametrize(
+    "source_id",
+    [
+        pytest.param("metric-123", id="nonempty"),
+        pytest.param("  metric-123  ", id="surrounding_whitespace"),
+    ],
+)
+def test_historical_reading_query_with_valid_source_id_succeeds(source_id: str) -> None:
+    query = HistoricalReadingQuery(source_id=source_id)
+
+    assert query.source_id == source_id
+
+
+def test_historical_reading_query_without_aggregate_by_defaults_empty() -> None:
+    query = HistoricalReadingQuery(source_id="metric-123")
+
+    assert query.aggregate_by == []
+
+
+def test_historical_setting_query_with_default_aggregate_by_isolates_lists() -> None:
+    source = HistoricalSettingQuerySource(setting_id="setting-1")
+    query_a = HistoricalSettingQuery(source=source, aggregate_by=[AggregateBy.avg])
+    query_b = HistoricalSettingQuery(source=source)
+
+    query_a.aggregate_by.append(AggregateBy.max)
+
+    assert query_b.aggregate_by == []
+
+
+def test_historical_setting_query_without_aggregate_by_defaults_empty() -> None:
+    source = HistoricalSettingQuerySource(setting_id="setting-1")
+    query = HistoricalSettingQuery(source=source)
+
+    assert query.aggregate_by == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        pytest.param("device_id", "", id="device_id_empty"),
+        pytest.param("device_id", "   ", id="device_id_whitespace"),
+        pytest.param("setting_alias", "", id="setting_alias_empty"),
+        pytest.param("setting_id", "", id="setting_id_empty"),
+        pytest.param("setting_id", "   ", id="setting_id_whitespace"),
+    ],
+)
+def test_historical_setting_query_source_with_empty_field_raises_validation_error(
+    field: str,
+    value: str,
+) -> None:
+    with pytest.raises(ValidationError, match="must be a non-empty string"):
+        HistoricalSettingQuerySource(**{field: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        pytest.param("device_id", None, id="device_id_none"),
+        pytest.param("device_id", "device-1", id="device_id_nonempty"),
+        pytest.param("setting_alias", None, id="setting_alias_none"),
+        pytest.param("setting_alias", "max-capacity", id="setting_alias_nonempty"),
+        pytest.param("setting_id", None, id="setting_id_none"),
+        pytest.param("setting_id", "setting-1", id="setting_id_nonempty"),
+    ],
+)
+def test_historical_setting_query_source_with_valid_field_succeeds(
+    field: str,
+    value: str | None,
+) -> None:
+    source = HistoricalSettingQuerySource(**{field: value})
+
+    assert getattr(source, field) == value
+
+
+@pytest.mark.parametrize(
+    ("name", "device_kind", "alias_regex", "expected"),
+    [
+        pytest.param(
+            CompressorMetric.suction_pressure.value,
+            DeviceKind.compressor,
+            "",
+            True,
+            id="known_name",
+        ),
+        pytest.param("UnknownMetric", DeviceKind.compressor, "", False, id="unknown_name"),
+        pytest.param(
+            CompressorMetric.suction_pressure.value,
+            DeviceKind.condenser,
+            "",
+            False,
+            id="wrong_device_kind",
+        ),
+        pytest.param("", DeviceKind.compressor, ".*Current.*", True, id="alias_regex_only"),
+        pytest.param("", DeviceKind.compressor, "", False, id="no_name_or_alias"),
+    ],
+)
+def test_is_valid_metric_with_metric_returns_validity(
+    name: str,
+    device_kind: DeviceKind,
+    alias_regex: str,
+    expected: bool,
+) -> None:
+    metric = DeviceMetric(
+        device_kind=device_kind,
+        name=name,
+        alias_regex=alias_regex,
+        metric_type=MetricType.control_point,
+    )
+
+    assert is_valid_metric(metric) is expected
+
+
+def test_is_valid_metric_with_unmapped_kind_raises_key_error() -> None:
+    metric = DeviceMetric(
+        device_kind=DeviceKind.energy_meter,
+        name=CompressorMetric.suction_pressure.value,
+        metric_type=MetricType.control_point,
+    )
+
+    with pytest.raises(KeyError):
+        is_valid_metric(metric)
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "payload", "expected_metric_type"),
+    [
+        pytest.param(
+            ControlPoint,
+            {
+                "control_point_id": "id-1",
+                "alias": "alias-1",
+                "bias": "bias",
+                "type": "type",
+            },
+            MetricType.control_point,
+            id="control_point",
+        ),
+        pytest.param(
+            Metric,
+            {
+                "metric_id": "id-1",
+                "alias": "alias-1",
+                "kind": "kind",
+            },
+            MetricType.metric,
+            id="metric",
+        ),
+        pytest.param(
+            Output,
+            {
+                "output_id": "id-1",
+                "alias": "alias-1",
+                "kind": "kind",
+            },
+            MetricType.output,
+            id="output",
+        ),
+        pytest.param(
+            Condition,
+            {
+                "condition_id": "id-1",
+                "alias": "alias-1",
+            },
+            MetricType.condition,
+            id="condition",
+        ),
+        pytest.param(
+            Setting,
+            {
+                "setting_id": "setting-1",
+                "name": "MaxCapacity",
+                "kind": "number",
+                "unit": "kW",
+            },
+            MetricType.setting,
+            id="setting",
+        ),
+    ],
+)
+def test_metric_type_property_with_instance_returns_type(
+    model_cls: type[ControlPoint] | type[Metric] | type[Output] | type[Condition] | type[Setting],
+    payload: dict[str, Any],
+    expected_metric_type: MetricType,
+) -> None:
+    instance = model_cls.model_validate(payload)
+
+    assert instance.metric_type == expected_metric_type
+
+
+def test_setting_alias_property_returns_name() -> None:
+    setting = Setting.model_validate(
+        {
+            "setting_id": "setting-1",
+            "name": "MaxCapacity",
+            "kind": "number",
+            "unit": "kW",
+        },
+    )
+
+    assert setting.alias == "MaxCapacity"
+
+
+def test_setting_result_sequence_value_item_with_camel_case_parses_stage_values() -> None:
+    item = SettingResultSequenceValueItem.model_validate(
+        {
+            "name": "stage-1",
+            "stageValues": [1, 2, 3],
+        },
+    )
+
+    assert item.name == "stage-1"
+    assert item.stage_values == [1, 2, 3]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,6 @@ from atlas.models import (
     MetricType,
     Output,
     Setting,
-    SettingResultSequenceValueItem,
     VesselMetric,
     construct_from_metric_name,
     is_valid_metric,
@@ -88,21 +87,6 @@ def test_construct_from_metric_name_with_unmapped_kind_raises_key_error() -> Non
         construct_from_metric_name("DischargePressure", DeviceKind.energy_meter)
 
 
-def test_control_point_with_payload_parses_id_and_unit() -> None:
-    control_point = ControlPoint.model_validate(
-        {
-            "control_point_id": "cp-1",
-            "alias": "SuctionPressure",
-            "bias": "direct",
-            "type": "analog",
-            "unit": "psi",
-        },
-    )
-
-    assert control_point.id == "cp-1"
-    assert control_point.unit == "psi"
-
-
 def test_device_associations_with_default_upstream_isolates_lists() -> None:
     associations_a = DeviceAssociations()
     associations_b = DeviceAssociations()
@@ -111,51 +95,6 @@ def test_device_associations_with_default_upstream_isolates_lists() -> None:
 
     assert associations_b.upstream == []
     assert associations_a.downstream == []
-
-
-def test_device_metric_with_alias_regex_and_type_succeeds() -> None:
-    metric = DeviceMetric.model_validate(
-        {
-            "device_kind": DeviceKind.compressor,
-            "alias_regex": ".*Current.*",
-            "metric_type": MetricType.control_point,
-        },
-    )
-
-    assert metric.alias_regex == ".*Current.*"
-    assert metric.metric_type == MetricType.control_point
-
-
-@pytest.mark.parametrize(
-    "payload",
-    [
-        pytest.param(
-            {"device_kind": DeviceKind.compressor, "alias_regex": ".*Current.*"},
-            id="missing_metric_type",
-        ),
-        pytest.param(
-            {"device_kind": DeviceKind.compressor, "name": "", "alias_regex": ".*Current.*"},
-            id="empty_name",
-        ),
-    ],
-)
-def test_device_metric_with_alias_regex_without_type_raises_validation_error(
-    payload: dict[str, object],
-) -> None:
-    with pytest.raises(ValidationError, match="metric_type must be provided when using alias_regex"):
-        DeviceMetric.model_validate(payload)
-
-
-def test_device_metric_with_explicit_type_uses_override() -> None:
-    metric = DeviceMetric.model_validate(
-        {
-            "device_kind": DeviceKind.compressor,
-            "name": CompressorMetric.suction_pressure.value,
-            "metric_type": MetricType.metric,
-        },
-    )
-
-    assert metric.metric_type == MetricType.metric
 
 
 @pytest.mark.parametrize(
@@ -167,13 +106,31 @@ def test_device_metric_with_explicit_type_uses_override() -> None:
         pytest.param(DeviceKind.vessel, VesselMetric.pressure.value, id="vessel"),
     ],
 )
-def test_device_metric_with_known_name_sets_metric_type(device_kind: DeviceKind, metric_name: str) -> None:
+def test_device_metric_auto_fill_metric_type_with_known_name_sets_metric_type(
+    device_kind: DeviceKind,
+    metric_name: str,
+) -> None:
     metric = DeviceMetric.model_validate({"device_kind": device_kind, "name": metric_name})
 
     assert metric.metric_type == MetricType.control_point
 
 
-def test_device_metric_with_unmapped_kind_raises_key_error() -> None:
+def test_device_metric_auto_fill_metric_type_with_type_uses_type() -> None:
+    metric = DeviceMetric(
+        device_kind=DeviceKind.compressor,
+        name=CompressorMetric.suction_pressure.value,
+        metric_type=MetricType.metric,
+    )
+
+    assert metric.metric_type == MetricType.metric
+
+
+def test_device_metric_auto_fill_metric_type_with_unknown_name_raises() -> None:
+    with pytest.raises(ValidationError):
+        DeviceMetric.model_validate({"device_kind": DeviceKind.compressor, "name": "UnknownMetric"})
+
+
+def test_device_metric_auto_fill_metric_type_with_unmapped_kind_raises() -> None:
     with pytest.raises(KeyError):
         DeviceMetric.model_validate(
             {
@@ -183,9 +140,24 @@ def test_device_metric_with_unmapped_kind_raises_key_error() -> None:
         )
 
 
-def test_device_metric_with_unknown_name_raises_validation_error() -> None:
-    with pytest.raises(ValidationError):
-        DeviceMetric.model_validate({"device_kind": DeviceKind.compressor, "name": "UnknownMetric"})
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            {"device_kind": DeviceKind.compressor, "alias_regex": ".*"},
+            id="missing_metric_type",
+        ),
+        pytest.param(
+            {"device_kind": DeviceKind.compressor, "name": "", "alias_regex": ".*"},
+            id="empty_name",
+        ),
+    ],
+)
+def test_device_metric_auto_fill_metric_type_without_name_and_type_raises(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="metric_type must be provided when using alias_regex"):
+        DeviceMetric.model_validate(payload)
 
 
 def test_historical_hourly_rate_start_datetime_returns_utc() -> None:
@@ -230,15 +202,6 @@ def test_historical_hourly_rates_to_hourly_rates_converts_each_field(
     assert converted[0].start == datetime.fromtimestamp(timestamp, tz=UTC)
 
 
-def test_historical_reading_query_with_default_aggregate_by_isolates_lists() -> None:
-    query_a = HistoricalReadingQuery(source_id="metric-a", aggregate_by=[AggregateBy.avg])
-    query_b = HistoricalReadingQuery(source_id="metric-b")
-
-    query_a.aggregate_by.append(AggregateBy.max)
-
-    assert query_b.aggregate_by == []
-
-
 @pytest.mark.parametrize(
     "source_id",
     [
@@ -246,7 +209,9 @@ def test_historical_reading_query_with_default_aggregate_by_isolates_lists() -> 
         pytest.param("   ", id="whitespace_only"),
     ],
 )
-def test_historical_reading_query_with_invalid_source_id_raises_validation_error(source_id: str) -> None:
+def test_historical_reading_query_validate_source_id_with_invalid_value_raises_validation_error(
+    source_id: str,
+) -> None:
     with pytest.raises(ValidationError, match="source_id must be a non-empty string"):
         HistoricalReadingQuery(source_id=source_id)
 
@@ -258,16 +223,63 @@ def test_historical_reading_query_with_invalid_source_id_raises_validation_error
         pytest.param("  metric-123  ", id="surrounding_whitespace"),
     ],
 )
-def test_historical_reading_query_with_valid_source_id_succeeds(source_id: str) -> None:
+def test_historical_reading_query_validate_source_id_with_valid_value_succeeds(source_id: str) -> None:
     query = HistoricalReadingQuery(source_id=source_id)
 
     assert query.source_id == source_id
+
+
+def test_historical_reading_query_with_default_aggregate_by_isolates_lists() -> None:
+    query_a = HistoricalReadingQuery(source_id="metric-a", aggregate_by=[AggregateBy.avg])
+    query_b = HistoricalReadingQuery(source_id="metric-b")
+
+    query_a.aggregate_by.append(AggregateBy.max)
+
+    assert query_b.aggregate_by == []
 
 
 def test_historical_reading_query_without_aggregate_by_defaults_empty() -> None:
     query = HistoricalReadingQuery(source_id="metric-123")
 
     assert query.aggregate_by == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        pytest.param("device_id", None, id="device_id_none"),
+        pytest.param("device_id", "device-1", id="device_id_nonempty"),
+        pytest.param("setting_alias", None, id="setting_alias_none"),
+        pytest.param("setting_alias", "max-capacity", id="setting_alias_nonempty"),
+        pytest.param("setting_id", None, id="setting_id_none"),
+        pytest.param("setting_id", "setting-1", id="setting_id_nonempty"),
+    ],
+)
+def test_historical_setting_query_source_validate_optional_non_empty_succeeds(
+    field: str,
+    value: str | None,
+) -> None:
+    source = HistoricalSettingQuerySource(**{field: value})
+
+    assert getattr(source, field) == value
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        pytest.param("device_id", "", id="device_id_empty"),
+        pytest.param("device_id", "   ", id="device_id_whitespace"),
+        pytest.param("setting_alias", "", id="setting_alias_empty"),
+        pytest.param("setting_id", "", id="setting_id_empty"),
+        pytest.param("setting_id", "   ", id="setting_id_whitespace"),
+    ],
+)
+def test_historical_setting_query_source_validate_optional_non_empty_with_empty_raises(
+    field: str,
+    value: str,
+) -> None:
+    with pytest.raises(ValidationError, match="must be a non-empty string"):
+        HistoricalSettingQuerySource(**{field: value})
 
 
 def test_historical_setting_query_with_default_aggregate_by_isolates_lists() -> None:
@@ -285,44 +297,6 @@ def test_historical_setting_query_without_aggregate_by_defaults_empty() -> None:
     query = HistoricalSettingQuery(source=source)
 
     assert query.aggregate_by == []
-
-
-@pytest.mark.parametrize(
-    ("field", "value"),
-    [
-        pytest.param("device_id", "", id="device_id_empty"),
-        pytest.param("device_id", "   ", id="device_id_whitespace"),
-        pytest.param("setting_alias", "", id="setting_alias_empty"),
-        pytest.param("setting_id", "", id="setting_id_empty"),
-        pytest.param("setting_id", "   ", id="setting_id_whitespace"),
-    ],
-)
-def test_historical_setting_query_source_with_empty_field_raises_validation_error(
-    field: str,
-    value: str,
-) -> None:
-    with pytest.raises(ValidationError, match="must be a non-empty string"):
-        HistoricalSettingQuerySource(**{field: value})
-
-
-@pytest.mark.parametrize(
-    ("field", "value"),
-    [
-        pytest.param("device_id", None, id="device_id_none"),
-        pytest.param("device_id", "device-1", id="device_id_nonempty"),
-        pytest.param("setting_alias", None, id="setting_alias_none"),
-        pytest.param("setting_alias", "max-capacity", id="setting_alias_nonempty"),
-        pytest.param("setting_id", None, id="setting_id_none"),
-        pytest.param("setting_id", "setting-1", id="setting_id_nonempty"),
-    ],
-)
-def test_historical_setting_query_source_with_valid_field_succeeds(
-    field: str,
-    value: str | None,
-) -> None:
-    source = HistoricalSettingQuerySource(**{field: value})
-
-    assert getattr(source, field) == value
 
 
 @pytest.mark.parametrize(
@@ -363,7 +337,7 @@ def test_is_valid_metric_with_metric_returns_validity(
     assert is_valid_metric(metric) is expected
 
 
-def test_is_valid_metric_with_unmapped_kind_raises_key_error() -> None:
+def test_is_valid_metric_with_unmapped_kind_raises() -> None:
     metric = DeviceMetric(
         device_kind=DeviceKind.energy_meter,
         name=CompressorMetric.suction_pressure.value,
@@ -441,25 +415,11 @@ def test_metric_type_property_with_instance_returns_type(
 
 
 def test_setting_alias_property_returns_name() -> None:
-    setting = Setting.model_validate(
-        {
-            "setting_id": "setting-1",
-            "name": "MaxCapacity",
-            "kind": "number",
-            "unit": "kW",
-        },
+    setting = Setting(
+        setting_id="setting-1",
+        name="MaxCapacity",
+        kind="number",
+        unit="kW",
     )
 
     assert setting.alias == "MaxCapacity"
-
-
-def test_setting_result_sequence_value_item_with_camel_case_parses_stage_values() -> None:
-    item = SettingResultSequenceValueItem.model_validate(
-        {
-            "name": "stage-1",
-            "stageValues": [1, 2, 3],
-        },
-    )
-
-    assert item.name == "stage-1"
-    assert item.stage_values == [1, 2, 3]

--- a/tests/test_time_helpers.py
+++ b/tests/test_time_helpers.py
@@ -1,5 +1,47 @@
+from datetime import UTC, datetime
+
+import pytest
+
 from atlas.time_helpers import parse_dt
 
 
-def test_parse_dt_none_returns_none() -> None:
-    assert parse_dt(None) is None
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        # ISO-8601 with Z
+        ("2026-07-10T19:07:00Z", datetime(2026, 7, 10, 19, 7, 0, tzinfo=UTC)),
+        # ISO-8601 with explicit UTC offset
+        ("2026-07-10T19:07:00+00:00", datetime(2026, 7, 10, 19, 7, 0, tzinfo=UTC)),
+        ("2026-07-10T19:07:00-00:00", datetime(2026, 7, 10, 19, 7, 0, tzinfo=UTC)),
+        # ISO-8601 without timezone (UTC assumed)
+        ("2026-07-10T19:07:00", datetime(2026, 7, 10, 19, 7, 0, tzinfo=UTC)),
+        ("2026-01-01T00:00:00", datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)),
+        ("2026-12-31T23:59:59", datetime(2026, 12, 31, 23, 59, 59, tzinfo=UTC)),
+        # "YYYY-MM-DD HH:MM:SS" without timezone (UTC assumed)
+        ("2026-07-10 19:07:00", datetime(2026, 7, 10, 19, 7, 0, tzinfo=UTC)),
+        ("2026-01-01 00:00:00", datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)),
+        # Fractional seconds
+        ("2026-07-10T19:07:00.123Z", datetime(2026, 7, 10, 19, 7, 0, 123_000, tzinfo=UTC)),
+        ("2026-07-10T19:07:00.123456Z", datetime(2026, 7, 10, 19, 7, 0, 123_456, tzinfo=UTC)),
+        ("2026-07-10T19:07:00.5", datetime(2026, 7, 10, 19, 7, 0, 500_000, tzinfo=UTC)),
+        ("2026-07-10 19:07:00.25", datetime(2026, 7, 10, 19, 7, 0, 250_000, tzinfo=UTC)),
+        # Non-UTC offsets normalized to UTC
+        ("2026-07-10T19:07:00+05:00", datetime(2026, 7, 10, 14, 7, 0, tzinfo=UTC)),
+        ("2026-07-10T19:07:00-04:00", datetime(2026, 7, 10, 23, 7, 0, tzinfo=UTC)),
+        ("2026-07-10T19:07:00+05:30", datetime(2026, 7, 10, 13, 37, 0, tzinfo=UTC)),
+        ("2026-07-10 19:07:00+05:00", datetime(2026, 7, 10, 14, 7, 0, tzinfo=UTC)),
+    ],
+    ids=lambda p: str(p),
+)
+def test_parse_dt(value: str | None, expected: datetime | None) -> None:
+    result = parse_dt(value)
+    assert result == expected
+    if result is not None:
+        assert result.tzinfo is UTC
+
+
+@pytest.mark.parametrize("value", ["not-a-datetime", "2026-13-45T99:99:99", "2026/07/10 19:07:00"])
+def test_parse_dt_raises(value: str) -> None:
+    with pytest.raises(ValueError):
+        parse_dt(value)


### PR DESCRIPTION
## Issue

Closes APP-395

## Description

Adds initial unit tests and establishes test patterns. This PR is only to demonstrate the various unit testing patterns with a select few tests; achieving adequate unit test coverage is not in scope.

## Key Changes
- Adds `requests-mock` to patch and mock out responses for the requests library
- Adds `pyfakefs` to mock file system behaviors (to test loading refresh token from file)
- Adds `pytest-mock` wrapper providing fixtures for `unittest.mock`
- Uses `unittest.mock` to do standard mocking
- Tests leveraging each of the above in various ways to establish unit testing patterns

## Testing

- New tests executing as expected locally and in CI